### PR TITLE
Add git mainline alias and command for listing relevant commits

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -28,6 +28,9 @@
 	# get the name of the main branch (from origin/HEAD), with fallback to "master".
 	mainline = !git get-name origin/HEAD | sed 's|origin/||' | sed 's|^HEAD$|master|'
 
+	# commits from current branch unmerged to mainline
+	# and commits from upstream branch unmerged to local branch
+	l = !git lg --boundary $(git commits-relevant-to-current-branch)
 [push]
 	default = tracking
 [merge]

--- a/.gitconfig
+++ b/.gitconfig
@@ -22,6 +22,12 @@
 	email-private = config user.email kosashi@gmail.com
 	email-work = config user.email kos@codility.com
 	recent = !"A=$(git branch --sort=-committerdate |smenu -n 20 -d -l) && git checkout $A"
+
+	# return ref name (useful e.g. for translating HEAD to branch name)
+	get-name = !git rev-parse --abbrev-ref 2>/dev/null
+	# get the name of the main branch (from origin/HEAD), with fallback to "master".
+	mainline = !git get-name origin/HEAD | sed 's|origin/||' | sed 's|^HEAD$|master|'
+
 [push]
 	default = tracking
 [merge]

--- a/.local/bin/git-commits-relevant-to-current-branch
+++ b/.local/bin/git-commits-relevant-to-current-branch
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Return commit range relevant to current branch:
+# - new local commits (unpushed to upstream branch)
+# - new remote commits (unmerged from upstream branch)
+# - any other commits from current branch not merged into mainline
+#
+# requires "git mainline" alias (see main git config file)
+
+mainline=$(git mainline)  # usually master
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+# if we're on detached HEAD, there will be no upstream - filter it out
+upstream=$(echo $current_branch@{upstream} | sed 's/HEAD@{upstream}//')
+
+# exclude commits from origin/$mainline, except when that's the branch we're on
+if [ $current_branch = $mainline ]; then
+  echo $current_branch...$upstream
+else
+  echo $current_branch $upstream ^origin/$mainline
+fi


### PR DESCRIPTION
See comments for details. Note that this assumes that `.local/bin` is in your
`$PATH` (so that new `git commits-relevant-to-current-branch` command will be
available).